### PR TITLE
Passare true a TApplication::Run()

### DIFF
--- a/Lezione_03/Esercizi/esercizio02.cpp
+++ b/Lezione_03/Esercizi/esercizio02.cpp
@@ -21,7 +21,10 @@ int main (int argc, char ** argv)
   TCanvas * c1 = new TCanvas () ;
   histo->Draw () ;
   c1->Print ("histo.png", "png") ;
-  theApp->Run () ;
+
+  // Importante: bisogna passare `true` per evitare che l'applicazione esca
+  // subito senza eseguire il codice successivo a TApplication::Run()
+  theApp->Run (true) ;
 
   delete histo ;
   delete theApp ;


### PR DESCRIPTION
Bisogna passare `true` a `TApplication::Run(Bool_t retrn = kFALSE)` altrimenti il codice successivo non viene eseguito perché il programma esce direttamente.

Riferimenti:

- https://root.cern/doc/master/classTApplication.html#a49ee3476597351ae4c55e26d5a7d4e66
- https://root.cern/doc/master/TApplication_8cxx_source.html#l01685